### PR TITLE
Rewrite /account specs

### DIFF
--- a/spec/requests/telegram_account_spec.rb
+++ b/spec/requests/telegram_account_spec.rb
@@ -1,14 +1,23 @@
 RSpec.describe "/account", telegram_bot: :rails do
-  it "should tell you to go to the website" do
-    expect {dispatch_command :account}
-    .to respond_with_message(/To connect, disconnect or delete your account/)
+  before(:example) do
+    dispatch_message("/account")
   end
 
-  it "should have an inline keyboard" do
-    dispatch_message("/account")
-    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
-    .to be_present
-    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
-    .to include("Log In")
+  it "should respond with the right message" do
+    expect(bot.requests[:sendMessage].last[:text])
+    .to  include("To connect, disconnect or delete your account")
+    .and include("use the button below or go to")
+    .and include("and log in.")
+  end
+
+  it "should have a single button" do
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+    .to eq(1)
+  end
+
+  it "should allow logging in through the button" do
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+    .to  include("\"Log In\"")
+    .and include("/auth/telegram/callback\"")
   end
 end


### PR DESCRIPTION
Closes #14 in combination with previous reworks on `/help` and `/commands` specs.