### PR TITLE
Permissive and strict registration filters

### DIFF
--- a/spec/requests/telegram_heroes_spec.rb
+++ b/spec/requests/telegram_heroes_spec.rb
@@ -41,29 +41,29 @@ RSpec.describe "/heroes", telegram_bot: :rails do
   let(:user) { create(:user, :steam_registered) }
 
   context "as an unregistered user" do
-    it "should say that user can't be found" do
+    it "should say you need to register" do
       expect { dispatch_message("/heroes") }
-      .to respond_with_message(/Can't find that user/)
+      .to respond_with_message(/You need to register before/)
     end
   end
 
   context "as an incomplete user" do
-    it "should say that user needs to complete their registration" do
+    it "should say that you need to complete their registration" do
       user = create(:user)
       expect { dispatch_message("/heroes", from: {id: user.telegram_id}) }
-      .to respond_with_message(/That user has not completed their registration/)
+      .to respond_with_message(/You need to complete your registration/)
     end
   end
 
   context "mentioning an unknown user" do
-    it "should fall back to the current user" do
+    it "should say that user can't be found" do
       expect(bot).to receive(:request).and_wrap_original do |m, *args|
         m.call(*args)
         {"ok"=>true, "result"=>{"message_id"=>120}}
       end
 
       expect { dispatch_message("/heroes asdfsf", from: {id: user.telegram_id}) }
-      .to respond_with_message(/Heroes for #{user.telegram_username}/)
+      .to respond_with_message(/Can't find that user/)
     end
   end
   

--- a/spec/requests/telegram_lastmatch_spec.rb
+++ b/spec/requests/telegram_lastmatch_spec.rb
@@ -10,18 +10,18 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
   let(:user) { create(:user, :steam_registered) }
 
   context "from an unregistered account" do
-    it "should say that user can't be found" do
+    it "should say you need to register" do
       expect{ dispatch_message("/lastmatch") }
-      .to respond_with_message(/Can't find that user/)
+      .to respond_with_message(/You need to register before you can use/)
     end
   end
 
   context "from an incomplete account" do
-    it "should tell that user they are not registered" do
+    it "should say you need to complete your registration" do
       user = create(:user)
 
       expect { dispatch_message("/lastmatch", from: {id: user.telegram_id}) }
-      .to respond_with_message(/That user has not completed their registration/)
+      .to respond_with_message(/You need to complete your registration/)
     end
   end
 

--- a/spec/requests/telegram_peers_spec.rb
+++ b/spec/requests/telegram_peers_spec.rb
@@ -8,30 +8,29 @@ RSpec.describe "/peers", telegram_bot: :rails do
   let(:user) { create(:user, :steam_registered) }
 
   context "as an unregistered user" do
-    it "should say that user can't be found" do
+    it "should say you need to register" do
       expect { dispatch_message("/peers") }
-      .to respond_with_message(/Can't find that user/)
+      .to respond_with_message(/You need to register before/)
     end
   end
 
   context "as an incomplete user" do
-    it "should say that user needs to complete their registration" do
+    it "should say you need to complete your registration" do
       user = create(:user)
       expect { dispatch_message("/peers", from: {id: user.telegram_id}) }
-      .to respond_with_message(/That user has not completed their registration/)
+      .to respond_with_message(/You need to complete your registration/)
     end
   end
 
   context "mentioning an unknown user" do
-    it "should fall back to the current user" do
+    it "should say that user can't be found" do
       expect(bot).to receive(:request).and_wrap_original do |m, *args|
         m.call(*args)
         {"ok"=>true, "result"=>{"message_id"=>100}}
       end
 
       expect { dispatch_message("/peers asdfsf", from: {id: user.telegram_id}) }
-      .to  respond_with_message(/Peers of #{user.telegram_username}/)
-      .and respond_with_message(/4 results/)
+      .to  respond_with_message(/Can't find that user/)
     end
   end
   

--- a/spec/requests/telegram_profile_spec.rb
+++ b/spec/requests/telegram_profile_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe "/profile", telegram_bot: :rails do
   end
 
   context "as an unregistered user" do
-    it "should tell the user they're not registered" do
+    it "should say you need to register" do
       expect {dispatch_message("/profile")}
-      .to respond_with_message(/Can't find that user/)
+      .to respond_with_message(/You need to register before/)
     end
   end
 
   context "as an incomplete user" do
-    it "should tell the user to complete their registration" do
+    it "should say you need to complete your registration" do
       user = create(:user)
       expect {dispatch_message("/profile", from: {id: user.telegram_id})}
-      .to respond_with_message(/That user has not completed their registration/)
+      .to respond_with_message(/You need to complete your registration/)
     end
   end
 
@@ -53,10 +53,11 @@ RSpec.describe "/profile", telegram_bot: :rails do
   end
 
   context "with invalid arguments" do
-    it "should assume the current user" do
+    it "should say it can't find that user" do
       user = create(:user, :steam_registered)
       dispatch_message("/profile asdsfgflkdg wehjkr", from: {id: user.telegram_id})
-      expect(bot.requests[:sendMessage].last[:text]).to include(user.steam_url)
+      expect(bot.requests[:sendMessage].last[:text])
+      .to include("Can't find that user")
     end
   end
 end

--- a/spec/requests/telegram_rank_spec.rb
+++ b/spec/requests/telegram_rank_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe "/rank", telegram_bot: :rails do
   end
   
   context "as an unregistered user" do
-    it "should say that user can't be found" do
+    it "should say you need to register" do
       expect { dispatch_message("/rank") }
-      .to respond_with_message(/Can't find that user/)
+      .to respond_with_message(/You need to register before/)
     end
   end
 
   context "as an incomplete user" do
-    it "should tell that user to complete their registration" do
+    it "should say you need to complete their registration" do
       user = create(:user)
       expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
-      .to respond_with_message(/has not completed their registration/)
+      .to respond_with_message(/You need to complete your registration/)
     end
   end
   
@@ -71,13 +71,11 @@ RSpec.describe "/rank", telegram_bot: :rails do
   end
 
   context "with an unknown user in args" do
-    it "should fall back to the original user" do
+    it "should say it can't find that user" do
       dispatch_message("/rank sdfkjsdkfsd", from: {id: user.telegram_id})
 
       expect(bot.requests[:sendMessage].last[:text])
-      .to  include("Legend 5")
-      .and include("@#{user.telegram_username}")
-      .and not_include("Can't find that user")
+      .to  include("Can't find that user")
     end
   end
 


### PR DESCRIPTION
Add a second option to filter for registered users: the previous default one is now a permissive one that passes to the command even if the first argument doesn't match a user, the new default now sends an error message when that happens. Fixes the incorrect fallback behavior to the user sending the message, closes #9.