### PR TITLE
Match buttons

### DIFF
--- a/app/controllers/concerns/button_proc_strings.rb
+++ b/app/controllers/concerns/button_proc_strings.rb
@@ -11,8 +11,8 @@ module ButtonProcStrings
         text = "\#{m.wl} \#{duration}min \#{m.rd} \#{m.kills}/\#{m.deaths}/\#{m.assists} " +
         "\#{hero_name(m.hero_id)} " +
         "\#{time_ago_in_words(Time.at(m.start_time))} ago"
-        callback = "nothing:0"
-        next text, callback
+        url = "https://opendota.com/matches/\#{m.match_id}"
+        next text, url
       end
     }
   end

--- a/app/controllers/telegram_players_controller.rb
+++ b/app/controllers/telegram_players_controller.rb
@@ -52,9 +52,10 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
     end
 
     result = respond_with :message, text: build_matches_header(@matches, options),
-             reply_markup: {inline_keyboard: build_paginated_buttons(@matches, match_button_proc_string)}
+             reply_markup: {inline_keyboard: build_paginated_url_buttons(@matches, match_button_proc_string)}
     message_session(result['result']['message_id'])
     message_session[:items] = @matches
+    message_session[:intention] = "matches"
     message_session[:page] = 1
     message_session[:button] = match_button_proc_string
     message_session[:player] = @player.id
@@ -70,12 +71,13 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
     session[:items] = @player.matches(session[:options])
     session[:page] = 1
     session[:button] = match_button_proc_string
+    session[:intention] = "matches"
 
     edit_message :text, text: build_matches_header(
       session[:items], session[:options]
     )
     edit_message :reply_markup, reply_markup: {
-      inline_keyboard: build_paginated_buttons(
+      inline_keyboard: build_paginated_url_buttons(
         session[:items], session[:button], session[:page]
       )
     }
@@ -103,6 +105,7 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
     session[:items] = @player.matches(session[:options])
     session[:page] = 1
     session[:button] = match_button_proc_string
+    session[:intention] = "matches"
     
     # These need to be nil or unintended buttons show up
     session[:hero_mode] = nil
@@ -112,7 +115,7 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
       session[:items], session[:options]
     )
     edit_message :reply_markup, reply_markup: {
-      inline_keyboard: build_paginated_buttons(
+      inline_keyboard: build_paginated_url_buttons(
         session[:items], session[:button], session[:page]
       )
     }

--- a/spec/requests/telegram_heroes_spec.rb
+++ b/spec/requests/telegram_heroes_spec.rb
@@ -418,8 +418,16 @@ RSpec.describe "/heroes", telegram_bot: :rails do
       .and include("Playing as Ember Spirit")
       .and include("5 results")
 
+      
       expect(bot.requests[:editMessageReplyMarkup].last[:reply_markup][:inline_keyboard].count)
       .to eq(5)
+
+      expect(bot.requests[:editMessageReplyMarkup].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("Ember Spirit")
+      .and include("W 30min")
+      .and include("\"https://opendota.com/matches/")
+      .and include(":url")
+      .and not_include(":callback_data")
     end
   end
 end

--- a/spec/requests/telegram_peers_spec.rb
+++ b/spec/requests/telegram_peers_spec.rb
@@ -493,6 +493,13 @@ RSpec.describe "/peers", telegram_bot: :rails do
 
       expect(bot.requests[:editMessageReplyMarkup].last[:reply_markup][:inline_keyboard].count)
       .to eq(4)
+
+      expect(bot.requests[:editMessageReplyMarkup].last[:reply_markup][:inline_keyboard].first.to_s)
+      .to  include("Anti-Mage")
+      .and include("W 30min")
+      .and include("\"https://opendota.com/matches/")
+      .and include(":url")
+      .and not_include(":callback_data")
     end
   end
 end


### PR DESCRIPTION
This makes match buttons use a different builder that can create url buttons, rather than callback buttons. Tests have been updated, but currently do not test whether link-through pagination (`/heroes` or `/peers`, click an item, go to another page) also returns valid buttons with links. Closes #30.