### PR TITLE
Handle join/leave messages

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
 web: authbind --deep bin/rails s -b 'ssl://127.0.0.1:443?key=config/certs/localhost-key.pem&cert=config/certs/localhost.pem'
 css: bin/rails tailwindcss:watch
-bot: bin/rails telegram:bot:poller

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ This is also why Authbind is required: if the webserver is not running HTTPS, Te
 For your convenience, the list of commands I pass to BotFather is also available in the repo as `bot_command_list.txt`.
 
 #### Development process
-* `bin/dev` to run the poller (Telegram), Puma (web) and Tailwind-builder in one window. They all live refresh, so you shouldn't need to restart them unless you make config changes.
+* **For bot work:** `rails telegram:bot:poller` to run the bot poller. I prefer not to include it in Foreman, because Puma doesn't handle hard crashes very well, and the poller will just die when it encounters a syntax error.
+* **For web/frontend work:** `bin/dev` to run Puma and Tailwind-builder in one window. They both live refresh, so you shouldn't need to restart them unless you make config changes.
 * Make your changes
 * `rspec` to run the test suite
 * Commit, push and submit a pull request!

--- a/spec/requests/telegram_spec.rb
+++ b/spec/requests/telegram_spec.rb
@@ -1,0 +1,99 @@
+RSpec.describe "Telegram bot", telegram_bot: :rails do
+  it "should welcome new group members" do
+    dispatch(message: {
+      from: {id: 12345, username: "asdfgh"},
+      chat: {id: 456},
+      new_chat_member: {
+        id: 12345, username: "asdfgh"
+      }
+    })
+
+    expect(bot.requests[:sendMessage].last[:text])
+    .to  include("Welcome! I can fetch your Dota 2 match data")
+    .and include("use the button below to log in with your Steam")
+
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+    .to eq(1)
+    
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+    .to  include("\"Log In\"")
+    .and include("/auth/telegram/callback\"")
+    .and include(":login_url")
+  end
+
+  it "should welcome incomplete users" do
+    user = create(:user)
+    dispatch(message: {
+      from: {id: user.telegram_id, username: user.telegram_username},
+      chat: {id: 456},
+      new_chat_member: {
+        id: user.telegram_id, username: user.telegram_username
+      }
+    })
+
+    expect(bot.requests[:sendMessage].last[:text])
+    .to  include("Welcome! I can fetch your Dota 2 match data")
+    .and include("use the button below to log in with your Steam")
+
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+    .to eq(1)
+    
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+    .to  include("\"Log In\"")
+    .and include("/auth/telegram/callback\"")
+    .and include(":login_url")
+  end
+
+  it "should not welcome users that are already registered" do
+    user = create(:user, :steam_registered)
+
+    dispatch(message: {
+      from: {id: user.telegram_id, username: user.telegram_username},
+      chat: {id: 456},
+      new_chat_member: {
+        id: user.telegram_id, username: user.telegram_username
+      }
+    })
+
+    expect(bot.requests[:sendMessage].count).to eq(0)
+  end
+
+  it "should not welcome itself" do
+    dispatch(message: {
+      from: {id: bot.id, username: bot.username},
+      chat: {id: 456},
+      new_chat_member: {
+        id: bot.id, username: bot.username
+      }
+    })
+
+    expect(bot.requests[:sendMessage].count).to eq(0)
+  end
+
+  it "should introduce itself when added to a group" do
+    user = create(:user, :steam_registered)
+    dispatch(my_chat_member: {
+      from: { id: user.telegram_id, username: user.telegram_username },
+      chat: { id: 456 },
+      new_chat_member: {
+        user: {
+          id: bot.id,
+          username: bot.username
+        }
+      }
+    })
+
+    expect(bot.requests[:sendMessage].last[:text])
+    .to  include("Hello! I can fetch your Dota 2 match data")
+    .and include("To let me show your stats, I will need")
+    .and include("log in with the button below and complete")
+
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
+    .to eq(1)
+
+    expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
+    .to  include("\"Log In\"")
+    .and include(":login_url")
+    .and include("/auth/telegram/callback\"")
+  end
+end


### PR DESCRIPTION
The bot should respond to joining a group and to a new user joining a group it is in, but everything else that is not an actionable command or a direct message should now not be responded to. Fixes #29.