### PR TITLE
Install rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,5 @@ gem 'steam-id2', '~> 0.4.5'
 gem 'hashie', '~> 5.0.0'
 
 gem "tailwindcss-rails", "~> 2.0"
+
+gem "rexml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,7 @@ DEPENDENCIES
   puma (~> 5.6)
   rails (~> 7.0.4)
   redis (~> 5.0.4)
+  rexml
   rspec-rails (~> 6.0.0.rc1)
   selenium-webdriver
   sprockets-rails


### PR DESCRIPTION
Since Ruby 3.x, rexml is no longer included by default and needs to be in the gemfile for certain things to work. It's worth a try, I suppose.