### PR TITLE
Auto-updating Telegram usernames, always downcase

### DIFF
--- a/app/controllers/concerns/hero_player_options.rb
+++ b/app/controllers/concerns/hero_player_options.rb
@@ -84,7 +84,7 @@ module HeroPlayerOptions
   end
 
   def hero_or_player(string)
-    Alias.find_by(name: string) || User.find_by(telegram_username: string)
+    Alias.find_by(name: string.downcase) || User.find_by(telegram_username: string.downcase)
   end
 
   def resolve_alias(string)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
 
     # Refresh user data if they're known, else create new user
     user = User.find_or_create_by(telegram_id: auth['uid'])
-    user.telegram_username = auth['info']['nickname']
+    user.telegram_username = auth['info']['nickname'].downcase
     user.telegram_avatar   = auth['info']['image']
     user.telegram_name     = auth['info']['name']
     user.save

--- a/app/controllers/telegram_players_controller.rb
+++ b/app/controllers/telegram_players_controller.rb
@@ -247,7 +247,7 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
     _, args = Telegram::Bot::UpdatesController::Commands.command_from_text(payload['text'], bot_username)
     if args.any?
       args[0] = args[0].tr("@", "")
-      @player = User.find_by(telegram_username: args[0])
+      @player = User.find_by(telegram_username: args[0].downcase)
       if @player.nil?
         respond_with :message, text: "Can't find that user!"
         throw(:filtered)
@@ -269,9 +269,12 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
 
   def permissive_logged_in_or_mentioning_player
     _, args = Telegram::Bot::UpdatesController::Commands.command_from_text(payload['text'], bot_username)
-    args[0] = args[0].tr("@", "") if args.any?
-    @player = User.find_by(telegram_username: args[0]) ||
-              User.find_by(telegram_id: from["id"])
+    if args.any?
+      args[0] = args[0].tr("@", "")
+      @player = User.find_by(telegram_username: args[0].downcase)
+    end
+    @player ||= User.find_by(telegram_id: from["id"])
+    
     if @player.nil?
       respond_with :message, text: "Can't find that user!"
       throw(:filtered)

--- a/app/controllers/telegram_webhooks_router.rb
+++ b/app/controllers/telegram_webhooks_router.rb
@@ -24,7 +24,7 @@ class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
       from = update["callback_query"]["from"]
     end
 
-    if defined?(from) && User.find_by(telegram_id: from["id"])
+    if defined?(from) && from && User.find_by(telegram_id: from["id"])
       user = User.find_by(telegram_id: from["id"])
       user.telegram_username = from["username"].downcase
       if from["last_name"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationRecord
 
     heroes = []
     p.heroes(opts).each do |hero|
-      h = Hero.find_by(hero_id: hero['hero_id'])
+      h = Hero.find_by(hero_id: hero['hero_id'].to_i)
       h.last_played =   hero['last_played']
       h.games =         hero['games']
       h.win =           hero['win']

--- a/spec/requests/telegram_heroes_spec.rb
+++ b/spec/requests/telegram_heroes_spec.rb
@@ -50,7 +50,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
   context "as an incomplete user" do
     it "should say that you need to complete their registration" do
       user = create(:user)
-      expect { dispatch_message("/heroes", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/heroes", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      }) }
       .to respond_with_message(/You need to complete your registration/)
     end
   end
@@ -62,7 +66,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>120}}
       end
 
-      expect { dispatch_message("/heroes asdfsf", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/heroes asdfsf", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      }) }
       .to respond_with_message(/Can't find that user/)
     end
   end
@@ -71,7 +79,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
     it "should say that user needs to complete their registration" do
       user2 = create(:user)
       expect { dispatch_message(
-        "/heroes #{user2.telegram_username}", from: {id: user.telegram_id}
+        "/heroes #{user2.telegram_username}", from: {
+          id: user.telegram_id,
+          username: user.telegram_username,
+          first_name: user.telegram_name
+        }
       ) }
       .to respond_with_message(/That user has not completed their registration/)
     end
@@ -84,7 +96,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>122}}
       end
 
-      dispatch_message("/heroes", from: {id: user.telegram_id})
+      dispatch_message("/heroes", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
     end
 
     it "should return a valid message" do
@@ -152,7 +168,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>124}}
       end
 
-      dispatch_message("/heroes", from: {id: user.telegram_id})
+      dispatch_message("/heroes", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
     end
 
     it "should start by games played as" do
@@ -285,7 +305,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
         array
       end
 
-      dispatch_message("/heroes", from: {id: user.telegram_id})
+      dispatch_message("/heroes", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
     end
 
     it "should have the correct amount of pages" do
@@ -403,7 +427,11 @@ RSpec.describe "/heroes", telegram_bot: :rails do
         build_list(:list_match, 5, hero_id: 106)
       }
 
-      dispatch_message("/heroes", from: {id: user.telegram_id})
+      dispatch_message("/heroes", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: user.telegram_name
+      })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].third.to_s)
       .to  include("Ember Spirit")

--- a/spec/requests/telegram_inline_spec.rb
+++ b/spec/requests/telegram_inline_spec.rb
@@ -35,7 +35,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "310",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: ""
         }
       )
@@ -66,7 +70,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "320",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: ""
         }
       )
@@ -129,7 +137,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "330",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "dfsdfsd"
         }
       )
@@ -146,7 +158,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "340",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "gondar"
         }
       )
@@ -190,7 +206,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "340",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "spirit"
         }
       )
@@ -200,7 +220,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "345",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "spirit"
         }
       )
@@ -222,7 +246,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "347",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "spirit"
         }
       )
@@ -248,7 +276,11 @@ RSpec.describe "Inline query", telegram_bot: :rails do
       dispatch(
         inline_query: {
           id:   "347",
-          from: {id: user.telegram_id},
+          from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          },
           query: "spirit"
         }
       )

--- a/spec/requests/telegram_lastmatch_spec.rb
+++ b/spec/requests/telegram_lastmatch_spec.rb
@@ -20,14 +20,22 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
     it "should say you need to complete your registration" do
       user = create(:user)
 
-      expect { dispatch_message("/lastmatch", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/lastmatch", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/You need to complete your registration/)
     end
   end
 
   context "from a valid account" do
     it "should return a valid message" do
-      dispatch_message("/lastmatch", from: {id: user.telegram_id})
+      dispatch_message("/lastmatch", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Recent match for #{user.telegram_username}")
@@ -45,14 +53,22 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
         ]
       end
 
-      dispatch_message("/lastmatch", from: {id: user.telegram_id})
+      dispatch_message("/lastmatch", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Loss in 30 mins")
     end
 
     it "should return a button to OpenDota" do
-      dispatch_message("/lastmatch", from: {id: user.telegram_id})
+      dispatch_message("/lastmatch", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
       .to  include("Match details on OpenDota")
@@ -73,7 +89,11 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
 
       expect { dispatch_message(
         "/lastmatch #{user2.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       ) }
       .to respond_with_message(/That user has not completed their registration/)
     end
@@ -85,7 +105,11 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
 
       dispatch_message(
         "/lastmatch #{user2.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])

--- a/spec/requests/telegram_login_spec.rb
+++ b/spec/requests/telegram_login_spec.rb
@@ -20,17 +20,23 @@ RSpec.describe "/login", telegram_bot: :rails do
   end
 
   context "as an account without steam registration" do
-    before(:example) do
-      @user = create(:user)
-    end
+    let(:user) { create(:user) }
 
     it 'should say to complete your registration' do
-      expect {dispatch_message("/login", from: {id: @user.telegram_id})}
+      expect {dispatch_message("/login", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })}
       .to respond_with_message(/To complete your registration, /)
     end
 
     it "should have an inline keyboard" do
-      dispatch_message("/login", from: {id: @user.telegram_id})
+      dispatch_message("/login", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
       .to be_present
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
@@ -39,12 +45,14 @@ RSpec.describe "/login", telegram_bot: :rails do
   end
   
   context "as a fully registered account" do
-    before(:example) do
-      @user = create(:user, :steam_registered)
-    end
+    let(:user) { create(:user, :steam_registered) }
 
     it 'should say you are registered' do
-      expect {dispatch_message("/login", from: {id: @user.telegram_id})}
+      expect {dispatch_message("/login", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })}
       .to respond_with_message(/Your registration is complete/)
     end
 
@@ -54,7 +62,11 @@ RSpec.describe "/login", telegram_bot: :rails do
     end
 
     it "should have an inline keyboard" do
-      dispatch_message("/login", from: {id: @user.telegram_id})
+      dispatch_message("/login", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard])
       .to be_present
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)

--- a/spec/requests/telegram_match_spec.rb
+++ b/spec/requests/telegram_match_spec.rb
@@ -39,7 +39,11 @@ RSpec.describe "/match", telegram_bot: :rails do
 
   context "with valid arguments" do
     it "should respond with a valid match message" do
-      expect { dispatch_message("/match 123456", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/match 123456", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/Match/)
       .and respond_with_message(/40 - 20/)
       .and respond_with_message(/Radiant victory in 30 minutes/)
@@ -70,7 +74,11 @@ RSpec.describe "/match", telegram_bot: :rails do
         build(:match, match_id: 12345)
       end
 
-      dispatch_message("/match 12345", from: {id: user.telegram_id})
+      dispatch_message("/match 12345", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].to_s)
       .to  include("Match details on OpenDota")

--- a/spec/requests/telegram_matches_spec.rb
+++ b/spec/requests/telegram_matches_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
     it "should tell the user they are not registered" do
       user = create(:user)
 
-      expect { dispatch_message("/matches", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/That user has not completed their registration/)
     end
   end
@@ -41,7 +45,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
       
       allow_any_instance_of(User).to receive(:matches) {build_list(:list_match, 4)}
 
-      expect { dispatch_message("/matches", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/4 results/)
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to match(/Anti-Mage about 1 hour ago/)
@@ -61,7 +69,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
         [listmatch]
       }
 
-      dispatch_message("/matches", from: {id: user.telegram_id} )
+      dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          } )
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("https://opendota.com/matches/#{listmatch.match_id}")
@@ -81,7 +93,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
         build_list(:list_match, 5) << listmatch
       }
 
-      dispatch_message("/matches", from: {id: user.telegram_id} )
+      dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          } )
 
       dispatch(callback_query: {
         data: "pagination:2", message: {message_id: 63, chat: {id: 456}}
@@ -101,7 +117,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       allow_any_instance_of(User).to receive(:matches) {build_list(:list_match, 38)}
 
-      expect { dispatch_message("/matches", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/38 results/)
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
       .to eq(6)
@@ -118,7 +138,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       allow_any_instance_of(User).to receive(:matches) {build_list(:list_match, 5)}
 
-      expect { dispatch_message("/matches", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/matches", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/5 results/)
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
       .to eq(5)
@@ -142,7 +166,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
         build_list(:list_match, 5, hero_id: 63)
       }
 
-      dispatch_message("/matches weaver", from: {id: user.telegram_id})
+      dispatch_message("/matches weaver", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Matches for #{user.telegram_username}")
@@ -164,7 +192,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches against venomancer with spectre as weaver",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -186,7 +218,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches weaver with earthshaker against venomancer and spectre with mars",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -210,7 +246,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches with #{user2.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -232,7 +272,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches #{user2.telegram_username} as weaver",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -254,7 +298,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches es",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -280,7 +328,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
 
       dispatch_message(
         "/matches es",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       dispatch(callback_query: {
@@ -306,7 +358,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
       
       dispatch_message(
         "/matches es against vs",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -354,7 +410,11 @@ RSpec.describe "/matches", telegram_bot: :rails do
       
       dispatch_message(
         "/matches es against vs",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       dispatch(callback_query: {

--- a/spec/requests/telegram_peers_spec.rb
+++ b/spec/requests/telegram_peers_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
   context "as an incomplete user" do
     it "should say you need to complete your registration" do
       user = create(:user)
-      expect { dispatch_message("/peers", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/You need to complete your registration/)
     end
   end
@@ -29,7 +33,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>100}}
       end
 
-      expect { dispatch_message("/peers asdfsf", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/peers asdfsf", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/Can't find that user/)
     end
   end
@@ -38,7 +46,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
     it "should say that user needs to complete their registration" do
       user2 = create(:user)
       expect { dispatch_message(
-        "/peers #{user2.telegram_username}", from: {id: user.telegram_id}
+        "/peers #{user2.telegram_username}", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       ) }
       .to respond_with_message(/That user has not completed their registration/)
     end
@@ -51,7 +63,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>101}}
       end
 
-      expect { dispatch_message("/peers", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/Peers of #{user.telegram_username}/)
       .and respond_with_message(/4 results/)
     end
@@ -66,7 +82,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         build_list(:peer, 1)
       }
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Peers of #{user.telegram_username}")
@@ -80,7 +100,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>103}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
       .to eq(5)
@@ -98,7 +122,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>104}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("Sort:")
@@ -118,7 +146,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         build_list(:peer, 1)
       }
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  not_include("Sort:")
@@ -138,7 +170,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         build_list(:peer, 12)
       }
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
       .to eq(7)
@@ -155,7 +191,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>107}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].count)
       .to eq(5)
@@ -189,7 +229,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>108}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("[Games]")
@@ -210,7 +254,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>109}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("[Games]")
@@ -237,7 +285,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>110}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("[Games]")
@@ -265,7 +317,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>111}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to  include("[Games]")
@@ -300,7 +356,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>112}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].last.to_s)
       .to include("1 / 5")
@@ -312,7 +372,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>113}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "pagination:2", message: {message_id: 113, chat: {id: 456}}
@@ -328,7 +392,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>114}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       row = bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].last
 
@@ -350,7 +418,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>115}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "pagination:2", message: {message_id: 115, chat: {id: 456}}
@@ -379,7 +451,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>116}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "pagination:3", message: {message_id: 116, chat: {id: 456}}
@@ -411,7 +487,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>117}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "pagination:4", message: {message_id: 117, chat: {id: 456}}
@@ -440,7 +520,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>118}}
       end
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "pagination:5", message: {message_id: 118, chat: {id: 456}}
@@ -478,7 +562,11 @@ RSpec.describe "/peers", telegram_bot: :rails do
         build_list(:list_match, 4)
       }
 
-      dispatch_message("/peers", from: {id: user.telegram_id})
+      dispatch_message("/peers", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].last.to_s)
       .to include("\"matches_with_player:#{user2.steam_id}\"")

--- a/spec/requests/telegram_profile_spec.rb
+++ b/spec/requests/telegram_profile_spec.rb
@@ -2,7 +2,11 @@ RSpec.describe "/profile", telegram_bot: :rails do
   context "as a registered user" do
     it "should respond with their steam url" do
       user = create(:user, :steam_registered)
-      dispatch_message("/profile", from: {id: user.telegram_id})
+      dispatch_message("/profile", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       expect(bot.requests[:sendMessage].last[:text]).to include(user.steam_url)
     end
   end
@@ -17,7 +21,11 @@ RSpec.describe "/profile", telegram_bot: :rails do
   context "as an incomplete user" do
     it "should say you need to complete your registration" do
       user = create(:user)
-      expect {dispatch_message("/profile", from: {id: user.telegram_id})}
+      expect {dispatch_message("/profile", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })}
       .to respond_with_message(/You need to complete your registration/)
     end
   end
@@ -32,7 +40,11 @@ RSpec.describe "/profile", telegram_bot: :rails do
     it "should not respond with the caller's steam link" do
       user  = create(:user, :steam_registered)
       user2 = create(:user, :steam_registered)
-      dispatch_message("/profile #{user2.telegram_username}", from: {id: user.telegram_id})
+      dispatch_message("/profile #{user2.telegram_username}", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       expect(bot.requests[:sendMessage].last[:text]).not_to include(user.steam_url)
     end
   end
@@ -55,7 +67,11 @@ RSpec.describe "/profile", telegram_bot: :rails do
   context "with invalid arguments" do
     it "should say it can't find that user" do
       user = create(:user, :steam_registered)
-      dispatch_message("/profile asdsfgflkdg wehjkr", from: {id: user.telegram_id})
+      dispatch_message("/profile asdsfgflkdg wehjkr", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
       expect(bot.requests[:sendMessage].last[:text])
       .to include("Can't find that user")
     end

--- a/spec/requests/telegram_rank_spec.rb
+++ b/spec/requests/telegram_rank_spec.rb
@@ -19,14 +19,22 @@ RSpec.describe "/rank", telegram_bot: :rails do
   context "as an incomplete user" do
     it "should say you need to complete their registration" do
       user = create(:user)
-      expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/rank", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/You need to complete your registration/)
     end
   end
   
   context "with no arguments" do
     it "should return the user's rank" do
-      expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/rank", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/@#{user.telegram_username}/)
       .and respond_with_message(/rank is Legend 5/)
     end
@@ -39,7 +47,11 @@ RSpec.describe "/rank", telegram_bot: :rails do
         }
       }
 
-      expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/rank", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/@#{user.telegram_username}/)
       .and respond_with_message(/Uncalibrated/)
     end
@@ -52,7 +64,11 @@ RSpec.describe "/rank", telegram_bot: :rails do
         }
       }
 
-      expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/rank", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/@#{user.telegram_username}/)
       .and respond_with_message(/Immortal 1234/)
     end
@@ -65,14 +81,22 @@ RSpec.describe "/rank", telegram_bot: :rails do
         }
       }
 
-      expect { dispatch_message("/rank", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/rank", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message("@#{user.telegram_username}'s rank is Immortal")
     end
   end
 
   context "with an unknown user in args" do
     it "should say it can't find that user" do
-      dispatch_message("/rank sdfkjsdkfsd", from: {id: user.telegram_id})
+      dispatch_message("/rank sdfkjsdkfsd", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Can't find that user")
@@ -85,7 +109,11 @@ RSpec.describe "/rank", telegram_bot: :rails do
 
       dispatch_message(
         "/rank #{user2.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])
@@ -101,7 +129,11 @@ RSpec.describe "/rank", telegram_bot: :rails do
 
       dispatch_message(
         "/rank #{user2.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )
 
       expect(bot.requests[:sendMessage].last[:text])

--- a/spec/requests/telegram_spec.rb
+++ b/spec/requests/telegram_spec.rb
@@ -1,4 +1,84 @@
 RSpec.describe "Telegram bot", telegram_bot: :rails do
+  describe "user data" do
+    let(:user) { create(:user, :steam_registered) }
+
+    it "should update user's username when they run a command" do
+      original_username = user.telegram_username
+      new_username = "abcdefg"
+
+      expect(user.telegram_username).to eq(original_username).and not_eq(new_username)
+
+      dispatch_message("/help", from: {
+        id: user.telegram_id,
+        username: new_username,
+        first_name: user.telegram_name
+      })
+
+      expect(user.reload.telegram_username).to eq(new_username).and not_eq(original_username)
+    end
+
+    it "should update user's name when they run a command" do
+      original_name = user.telegram_name
+      new_name = "Hello"
+
+      expect(user.telegram_name).to eq(original_name).and not_eq(new_name)
+
+      dispatch_message("/help", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: new_name
+      })
+
+      expect(user.reload.telegram_name).to eq(new_name).and not_eq(original_name)
+    end
+
+    it "should put first and last name together correctly" do
+      original_name = user.telegram_name
+
+      expect(user.telegram_name).to eq(original_name)
+
+      dispatch_message("/help", from: {
+        id: user.telegram_id,
+        username: user.telegram_username,
+        first_name: "Hello",
+        last_name: "World"
+      })
+
+      expect(user.reload.telegram_name).to eq("Hello World").and not_eq(original_name)
+    end
+
+    it "should update when user runs a callback query" do
+      dispatch(callback_query: {
+        data: "nothing:0", message: {message_id: 60, chat: {id: 456}},
+        from: {
+          id: user.telegram_id,
+          username: "hehexd",
+          first_name: "Lol Lmao"
+        }
+      })
+
+      expect(user.reload.telegram_username).to eq("hehexd")
+      expect(user.reload.telegram_name).to eq("Lol Lmao")
+    end
+
+    it "should update when user runs an inline query" do
+      dispatch(
+        inline_query: {
+          id:   "347",
+          from: {
+            id: user.telegram_id,
+            username: "hehexd",
+            first_name: "Lol Lmao"
+          },
+          query: "spirit"
+        }
+      )
+
+      expect(user.reload.telegram_username).to eq("hehexd")
+      expect(user.reload.telegram_name).to eq("Lol Lmao")
+    end
+  end
+
   it "should welcome new group members" do
     dispatch(message: {
       from: {id: 12345, username: "asdfgh"},

--- a/spec/requests/telegram_winrate_spec.rb
+++ b/spec/requests/telegram_winrate_spec.rb
@@ -10,7 +10,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
     it "should tell the user that they are not registered" do
       user = create(:user)
 
-      expect { dispatch_message("/winrate", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/winrate", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/That user has not completed their registration/)
     end
   end
@@ -41,7 +45,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
     let(:user) { create(:user, :steam_registered) }
 
     it "should give a global winrate" do
-      expect { dispatch_message("/winrate", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/winrate", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to  respond_with_message(/Winrate for #{user.telegram_username}:/)
       .and respond_with_message(/999 wins, 123 losses/)
     end
@@ -51,7 +59,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
         {"win" => 1, "lose" => 1}
       }
 
-      expect { dispatch_message("/winrate", from: {id: user.telegram_id}) }
+      expect { dispatch_message("/winrate", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }) }
       .to respond_with_message(/1 win, 1 loss/)
     end
   end
@@ -69,7 +81,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
 
       expect { dispatch_message(
         "/winrate weaver against razor with faceless void and spectre against dazzle",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )}
       .to  respond_with_message(/Winrate for #{user.telegram_username}:/)
       .and respond_with_message(/Playing as Weaver/)
@@ -82,7 +98,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
       user3 = create(:user, :steam_registered)
       expect { dispatch_message(
         "/winrate with #{user2.telegram_username} and #{user3.telegram_username}",
-        from: {id: user.telegram_id}
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
       )}
       .to  respond_with_message(/Winrate for #{user.telegram_username}:/)
       .and respond_with_message(
@@ -106,7 +126,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>80}}
       end
 
-      dispatch_message("/winrate void", from: {id: user.telegram_id})
+      dispatch_message("/winrate void", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to  include("Winrate for #{user.telegram_username}")
@@ -127,7 +151,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>81}}
       end
 
-      dispatch_message("/winrate void against es", from: {id: user.telegram_id})
+      dispatch_message("/winrate void against es", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       expect(bot.requests[:sendMessage].last[:text])
       .to include(">>\"void\"<<")
@@ -149,7 +177,11 @@ RSpec.describe "/winrate", telegram_bot: :rails do
         {"ok"=>true, "result"=>{"message_id"=>82}}
       end
 
-      dispatch_message("/winrate void against es", from: {id: user.telegram_id})
+      dispatch_message("/winrate void against es", from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          })
 
       dispatch(callback_query: {
         data: "alias:41", message: {message_id: 82, chat: {id: 456}}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,5 +93,6 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     RSpec::Matchers.define_negated_matcher :not_include, :include
+    RSpec::Matchers.define_negated_matcher :not_eq,      :eq
   end
 end


### PR DESCRIPTION
Telegram usernames can be capitalized, we want them to always be lowercase. This PR ensures that when a user is first saved to the database, their username is downcased. Additionally, a handler has been added to the commands router to gleam someone's Telegram ID from the update, and if they're registered, update their username and display name with the new information.

Fixes #40 and fixes #43.