### PR TITLE
Rename aliases to nicknames

### DIFF
--- a/app/controllers/concerns/alias_handling.rb
+++ b/app/controllers/concerns/alias_handling.rb
@@ -22,7 +22,7 @@ module AliasHandling
       key == :query && !object[:result] 
     end
     to_match = to_match.first[:query]
-    possible_matches = Alias.where(name: to_match).includes(:hero).order("heroes.localized_name")
+    possible_matches = Nickname.where(name: to_match).includes(:hero).order("heroes.localized_name")
     keyboard = []
     possible_matches.each do |match|
       keyboard << [

--- a/app/controllers/concerns/hero_player_options.rb
+++ b/app/controllers/concerns/hero_player_options.rb
@@ -84,11 +84,11 @@ module HeroPlayerOptions
   end
 
   def hero_or_player(string)
-    Alias.find_by(name: string.downcase) || User.find_by(telegram_username: string.downcase)
+    Nickname.find_by(name: string.downcase) || User.find_by(telegram_username: string.downcase)
   end
 
   def resolve_alias(string)
-    aliases = Alias.where(name: string)
+    aliases = Nickname.where(name: string)
     if aliases.any?
       if aliases.count == 1
         aliases.first.hero.hero_id

--- a/app/controllers/telegram_heroes_controller.rb
+++ b/app/controllers/telegram_heroes_controller.rb
@@ -11,7 +11,7 @@ class TelegramHeroesController < Telegram::Bot::UpdatesController
   def alias!(*args)
     if args.any?
       input = args.join(" ").downcase
-      aliases = Alias.where(name: input)
+      aliases = Nickname.where(name: input)
 
       case aliases.count
       when 0
@@ -40,7 +40,7 @@ class TelegramHeroesController < Telegram::Bot::UpdatesController
   def matchups!(*args)
     if args.any?
       input = args.join(" ").downcase
-      aliases = Alias.where(name: input)
+      aliases = Nickname.where(name: input)
 
       case aliases.count
       when 0
@@ -85,7 +85,7 @@ class TelegramHeroesController < Telegram::Bot::UpdatesController
 
   def build_alias_list_message(hero_id)
     message = []
-    aliases = Alias.where(hero_id: hero_id).order(:name)
+    aliases = Nickname.where(hero_id: hero_id).order(:name)
     message << "#{pluralize(aliases.count, "alias")} for " +
     "#{hero_name(hero_id)}:"
     aliases.each do |a|
@@ -114,7 +114,7 @@ class TelegramHeroesController < Telegram::Bot::UpdatesController
   end
 
   def build_single_alias_keyboard(input, intention)
-    aliases = Alias.where(name: input).includes(:hero).order("heroes.localized_name")
+    aliases = Nickname.where(name: input).includes(:hero).order("heroes.localized_name")
     keyboard = []
     aliases.each do |a|
       keyboard << [

--- a/app/controllers/telegram_inline_query_controller.rb
+++ b/app/controllers/telegram_inline_query_controller.rb
@@ -15,7 +15,7 @@ class TelegramInlineQueryController < Telegram::Bot::UpdatesController
       if query.blank?
         @matches = @player.matches(limit: 10)
       else
-        aliases = Alias.where(name: query.downcase)
+        aliases = Nickname.where(name: query.downcase)
         case aliases.count
         when 0
           @matches = @player.matches(limit: 10)

--- a/app/models/hero.rb
+++ b/app/models/hero.rb
@@ -16,7 +16,7 @@ class Hero < ApplicationRecord
   attribute :against_games,  default: nil
   attribute :against_win,    default: nil
 
-  has_many :aliases, primary_key: :hero_id
+  has_many :nicknames, primary_key: :hero_id
 
   serialize :roles
 
@@ -25,7 +25,7 @@ class Hero < ApplicationRecord
     ActiveRecord::Base.transaction do
       self.destroy_all
       # We're regenerating default aliases too
-      Alias.destroy_by(default: true)
+      Nickname.destroy_by(default: true)
 
       # Iterate over heroes OpenDota knows about and add them to our database
       OpendotaConstants.new("heroes").all.each_pair do |_, hero|
@@ -45,20 +45,20 @@ class Hero < ApplicationRecord
         h.localized_name = "Outworld Destroyer" if h.localized_name == "Outworld Devourer"
         
         h.save
-        h.generate_default_aliases
+        h.generate_default_nicknames
       end
     end
   end
 
-  def generate_default_aliases
+  def generate_default_nicknames
     name  = self.localized_name.downcase
     words = name.split(/[\s-]/)
 
     # The hero's full name
-    self.aliases.create(name: name, default: true)
+    self.nicknames.create(name: name, default: true)
 
     if name.include?("-")
-      self.aliases.create(name: name.tr("-", ""), default: true)
+      self.nicknames.create(name: name.tr("-", ""), default: true)
     end
 
     # If the hero's name consists of more than 2 words, an abbreviation,
@@ -68,9 +68,9 @@ class Hero < ApplicationRecord
       words.each do |word|
         abbreviation << word.chr
       end
-      self.aliases.create(name: abbreviation, default: true)
-      self.aliases.create(name: words.first,  default: true)
-      self.aliases.create(name: words.last,   default: true)
+      self.nicknames.create(name: abbreviation, default: true)
+      self.nicknames.create(name: words.first,  default: true)
+      self.nicknames.create(name: words.last,   default: true)
     end
   end
 

--- a/app/models/nickname.rb
+++ b/app/models/nickname.rb
@@ -1,4 +1,4 @@
-class Alias < ApplicationRecord
+class Nickname < ApplicationRecord
   validates :hero_id, presence: true
   validates :name,  presence: true,
                     format: { with: /\A[a-z\- ]+\z/, message: "must be lowercase letters only" },

--- a/db/migrate/20220917115059_change_aliases_to_nicknames.rb
+++ b/db/migrate/20220917115059_change_aliases_to_nicknames.rb
@@ -1,0 +1,5 @@
+class ChangeAliasesToNicknames < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :aliases, :nicknames
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_13_085358) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_17_115059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "aliases", force: :cascade do |t|
-    t.bigint "hero_id", null: false
-    t.string "name", null: false
-    t.boolean "default", default: false
-    t.boolean "from_seed", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["hero_id"], name: "index_aliases_on_hero_id"
-    t.index ["name"], name: "index_aliases_on_name"
-  end
 
   create_table "game_modes", force: :cascade do |t|
     t.integer "mode_id", null: false
@@ -75,6 +64,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_13_085358) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["lobby_id"], name: "index_lobby_types_on_lobby_id", unique: true
+  end
+
+  create_table "nicknames", force: :cascade do |t|
+    t.bigint "hero_id", null: false
+    t.string "name", null: false
+    t.boolean "default", default: false
+    t.boolean "from_seed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["hero_id"], name: "index_nicknames_on_hero_id"
+    t.index ["name"], name: "index_nicknames_on_name"
   end
 
   create_table "patches", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ LobbyType.refresh
 Patch.refresh
 Region.refresh
 
-Alias.destroy_by(from_seed: true)
+Nickname.destroy_by(from_seed: true)
 # Parse custom aliases from file
 # Aliases should be presented as an array of hashes, each
 # hash containing a "name" and a "hero_id" field
@@ -22,8 +22,8 @@ Alias.destroy_by(from_seed: true)
 # and we'll try and match it to the aliases currently on file
 aliases = JSON.parse(File.read("#{Rails.root}/db/hero_aliases.json"))
 aliases.each do |data|
-  a = Alias.new
-  a.hero_id   = data["hero_id"] || Alias.find_by(name: data["hero"]).hero.hero_id
+  a = Nickname.new
+  a.hero_id   = data["hero_id"] || Nickname.find_by(name: data["hero"]).hero.hero_id
   a.name      = data["name"].downcase
   a.from_seed = true
   a.save

--- a/spec/factories/nickname_factory.rb
+++ b/spec/factories/nickname_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :alias do
+  factory :nickname do
     hero_id { 1 }
     name { "hehexd" }
   end

--- a/spec/models/alias_specs.rb
+++ b/spec/models/alias_specs.rb
@@ -1,86 +1,86 @@
-RSpec.describe Alias do
+RSpec.describe Nickname do
   context "with valid attributes" do
     it "should be valid" do
-      expect( build(:alias) )
+      expect( build(:nickname) )
       .to be_valid
     end
   end
 
   context "hero ID" do
     it "should not be missing" do
-      expect( build(:alias, hero_id: nil) )
+      expect( build(:nickname, hero_id: nil) )
       .to be_invalid
     end
 
     it "should match a hero" do
-      expect( build(:alias, hero_id: 999) )
+      expect( build(:nickname, hero_id: 999) )
       .to be_invalid
     end
   end
 
   context "name" do
     it "should not be missing" do
-      expect( build(:alias, name: nil) )
+      expect( build(:nickname, name: nil) )
       .to be_invalid
     end
 
     it "should not be blank" do
-      expect( build(:alias, name: "") )
+      expect( build(:nickname, name: "") )
       .to be_invalid
     end
 
     it "should not be whitespace" do
-      expect( build(:alias, name: "    ") )
+      expect( build(:nickname, name: "    ") )
       .to be_invalid
     end
 
     it "should not contain capital letters" do
-      expect( build(:alias, name: "asDFgh") )
+      expect( build(:nickname, name: "asDFgh") )
       .to be_invalid
     end
 
     it "should not contain numbers" do
-      expect( build(:alias, name: "asdf456") )
+      expect( build(:nickname, name: "asdf456") )
       .to be_invalid
     end
 
     it "should not contain special characters" do
-      expect( build(:alias, name: "asd&") )
+      expect( build(:nickname, name: "asd&") )
       .to be_invalid
 
-      expect( build(:alias, name: "asd*") )
+      expect( build(:nickname, name: "asd*") )
       .to be_invalid
 
-      expect( build(:alias, name: "asd^") )
+      expect( build(:nickname, name: "asd^") )
       .to be_invalid
 
-      expect( build(:alias, name: "asd(") )
+      expect( build(:nickname, name: "asd(") )
       .to be_invalid
     end
 
     it "should be able to contain spaces" do
-      expect( build(:alias, name: "hello world") )
+      expect( build(:nickname, name: "hello world") )
       .to be_valid
     end
 
     it "should be able to contain a dash" do
-      expect( build(:alias, name: "asd-fgh") )
+      expect( build(:nickname, name: "asd-fgh") )
       .to be_valid
     end
   end
 
   context "duplicates" do
     it "should be valid for different heroes" do
-      create(:alias, name: "hehexd", hero_id: 1)
+      create(:nickname, name: "hehexd", hero_id: 1)
 
-      expect( build(:alias, name: "hehexd", hero_id: 2) )
+      expect( build(:nickname, name: "hehexd", hero_id: 2) )
       .to be_valid
     end
 
     it "should be invalid for the same hero" do
-      create(:alias, name: "asdfgh")
+      create(:nickname, name: "asdfgh")
 
-      expect( build(:alias, name: "asdfgh") )
+      expect( build(:nickname, name: "asdfgh") )
       .to be_invalid
     end
   end


### PR DESCRIPTION
Under the hood, aliases are now called nicknames to avoid collisions with the `alias` keyword in Ruby.