### PR TITLE
Downcase legacy usernames, fix caps handling bugs

### DIFF
--- a/app/controllers/concerns/hero_player_options.rb
+++ b/app/controllers/concerns/hero_player_options.rb
@@ -3,12 +3,14 @@ module HeroPlayerOptions
     delimiters = ["as", "with", "against", "and"]
 
     # Prepare the array
+    prepared_args = []
     args.each do |a|
-      a.downcase.tr("@", "")
+      prepared_args << a.downcase.tr("@", "")
     end
-    args.delete_at(0) if User.find_by(telegram_username: args[0])
+    
+    prepared_args.delete_at(0) if User.find_by(telegram_username: prepared_args[0])
     # Split it up
-    chunks = args.chunk { |v| v.in?(delimiters) }.to_a
+    chunks = prepared_args.chunk { |v| v.in?(delimiters) }.to_a
     # Array must start with a true chunk and end with a false one
     # It's okay to insert an invalid value here, we just don't want to
     # throw an exception at this stage

--- a/db/migrate/20220918133143_downcase_telegram_usernames.rb
+++ b/db/migrate/20220918133143_downcase_telegram_usernames.rb
@@ -1,0 +1,5 @@
+class DowncaseTelegramUsernames < ActiveRecord::Migration[7.0]
+  def change
+    User.update_all('telegram_username = lower(telegram_username)')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_17_115059) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_18_133143) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/requests/telegram_lastmatch_spec.rb
+++ b/spec/requests/telegram_lastmatch_spec.rb
@@ -116,5 +116,22 @@ RSpec.describe "/lastmatch", telegram_bot: :rails do
       .to  include(user2.telegram_username)
       .and not_include(user.telegram_username)
     end
+
+    it "should not care about capitalization" do
+      user2 = create(:user, :steam_registered)
+
+      dispatch_message(
+        "/lastmatch #{user2.telegram_username.upcase}",
+        from: {
+            id: user.telegram_id,
+            username: user.telegram_username,
+            first_name: user.telegram_name
+          }
+      )
+
+      expect(bot.requests[:sendMessage].last[:text])
+      .to  include(user2.telegram_username)
+      .and not_include(user.telegram_username)
+    end
   end
 end

--- a/spec/requests/telegram_matchups_spec.rb
+++ b/spec/requests/telegram_matchups_spec.rb
@@ -81,6 +81,18 @@ RSpec.describe "/matchups", telegram_bot: :rails do
       expect(bot.requests[:sendMessage].last[:reply_markup][:inline_keyboard].first.to_s)
       .to include("Ogre Magi")
     end
+
+    it "should not care about hero name capitalization" do
+      allow(bot).to receive(:request).and_wrap_original do |m, *args|
+        m.call(*args)
+        {"ok"=>true, "result"=>{"message_id"=>1000}}
+      end
+
+      expect { dispatch_message("/matchups ANTI-mage") }
+      .to  respond_with_message(/Matchups/)
+      .and respond_with_message(/Anti-Mage/)
+      .and respond_with_message(/Sorted by Wilson score/)
+    end
   end
 
   context "with an unclear alias" do


### PR DESCRIPTION
This fixes a few bugs related to what happens when entering not-downcased usernames and hero aliases, and also transforms any not-downcased names still lingering in the databse.