### PR TITLE
Add StandardError rescue to Telegram controllers

### DIFF
--- a/app/controllers/concerns/error_handling.rb
+++ b/app/controllers/concerns/error_handling.rb
@@ -1,0 +1,38 @@
+module ErrorHandling
+  
+  private
+  def error_out(exception)
+    backtrace_size = exception.backtrace.size
+    if backtrace_size >= 2 then max_range = 2
+    elsif backtrace_size >= 1 then max_range = 1
+    end
+    if max_range > 0      
+      s = "rescued_from: #{exception.inspect}\n#{exception.backtrace[0..max_range].to_s}\n"
+      logger.error s
+    end
+
+    if update["message"]
+      bot.send_message(
+        text: "Something went wrong, sorry!",
+        chat_id: update["message"]["chat"]["id"]
+      )
+    elsif update["callback_query"]
+      bot.answer_callback_query(
+        text: "Something went wrong, sorry!",
+        callback_query_id: update["callback_query"]["id"]
+      )
+    elsif update["inline_query"]
+      bot.answer_inline_query(
+        inline_query_id: update["inline_query"]["id"],
+        results: [
+          {
+            type: "article",
+            id: 0,
+            title: "Something went wrong, sorry!"
+          }
+        ],
+        cache_time: 10
+      )
+    end
+  end 
+end

--- a/app/controllers/telegram_help_controller.rb
+++ b/app/controllers/telegram_help_controller.rb
@@ -2,8 +2,10 @@ class TelegramHelpController < Telegram::Bot::UpdatesController
   include Telegram::Bot::UpdatesController::MessageContext
   include Telegram::Bot::UpdatesController::CallbackQueryContext
   include LoginUrl
-  # Generic help commands
 
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
+  
   def help!(*)
     respond_with :message,
     text: "Click the buttons below for the help page, and a list of commands!",

--- a/app/controllers/telegram_heroes_controller.rb
+++ b/app/controllers/telegram_heroes_controller.rb
@@ -8,6 +8,9 @@ class TelegramHeroesController < Telegram::Bot::UpdatesController
   include MessageSession
   include ConstantsHelper
 
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
+
   def alias!(*args)
     if args.any?
       input = args.join(" ").downcase

--- a/app/controllers/telegram_inline_query_controller.rb
+++ b/app/controllers/telegram_inline_query_controller.rb
@@ -5,6 +5,9 @@ class TelegramInlineQueryController < Telegram::Bot::UpdatesController
   include LoginUrl
   include ConstantsHelper
 
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
+
   def inline_query(query, _offset)
     @player ||= User.find_by(telegram_id: from['id'])
     

--- a/app/controllers/telegram_matches_controller.rb
+++ b/app/controllers/telegram_matches_controller.rb
@@ -7,6 +7,9 @@ class TelegramMatchesController < Telegram::Bot::UpdatesController
   include MatchMessages
   include MessageSession
 
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
+
   def match!(*args)
     if args.any? && args.count == 1 && args.first.to_i > 0
       match_id = args.first.to_i

--- a/app/controllers/telegram_players_controller.rb
+++ b/app/controllers/telegram_players_controller.rb
@@ -13,6 +13,9 @@ class TelegramPlayersController < Telegram::Bot::UpdatesController
   include OpendotaHelper
   include MatchMessages
 
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
+
   before_action :logged_in_or_mentioning_player, only: [:rank!,      :profile!,
                                                         :peers!,     :heroes!,
                                                         :lastmatch!]

--- a/app/controllers/telegram_users_controller.rb
+++ b/app/controllers/telegram_users_controller.rb
@@ -2,6 +2,8 @@ class TelegramUsersController < Telegram::Bot::UpdatesController
   include Telegram::Bot::UpdatesController::MessageContext
   include TelegramHelper
   include LoginUrl
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
   # Mostly for making a signin button to the site
   # if you're looking for player data commands, check TelegramPlayersController
 

--- a/app/controllers/telegram_webhooks_router.rb
+++ b/app/controllers/telegram_webhooks_router.rb
@@ -1,7 +1,8 @@
 class TelegramWebhooksRouter < Telegram::Bot::UpdatesController
   include Telegram::Bot::UpdatesController::MessageContext
-
   include LoginUrl
+  include ErrorHandling
+  rescue_from StandardError, with: :error_out
 
   # Dispatch the message to each Telegram controller,
   # until one of them handles it. If none handle it, super


### PR DESCRIPTION
Add a `rescue_from` to all Telegram controllers so errors can be handled gracefully, instead of holding up the whole webhook chain. There's a logging component to ensure the stacktrace and fact that an exception happened do not get eaten completely. Hopefully it works!