### PR TITLE
Redis cache expires after a week

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,7 +93,7 @@ Rails.application.configure do
 
   # Configure session store for telegram bot.
   config.telegram_updates_controller.session_store = :redis_cache_store,
-    { expires_in: 1.month }
+    { expires_in: 1.week }
 
   config.force_ssl = true
 


### PR DESCRIPTION
This changes the redis expiry from 1 month in the future to 1 week in the future. There's no need to keep data around for that long. Closes #66 