### PR TITLE
Update github actions workflows for real CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,23 @@
 # Clone the repo and run the test suite
 
-name: Deploy
+name: Test and Deploy
 
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the "main" branch
-  release:
-    types: [released]
+  push:
+    branches:  [ "main" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
+  test:
+    name: Run tests
+    uses: cschuijt/dotagem/.github/workflows/tests.yml@main
+
   deploy:
+    name: Deploy to production
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,10 @@ name: Tests
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
-  push:
-    branches:  [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Allows this workflow to be called from the deploy one
+  workflow_call:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Upgrade continuous deployment to actually be continuous, with each merge into main automatically being deployed. After trying a slower development cycle for a bit, this seems like a better fit, and allows for adding new features whenever it's convenient.